### PR TITLE
fix: ucf batch size bug

### DIFF
--- a/training/detectors/ucf_detector.py
+++ b/training/detectors/ucf_detector.py
@@ -281,7 +281,7 @@ class UCFDetector(AbstractDetector):
             pred_dict = {'cls': out_sha, 'feat': sha_feat}
             return  pred_dict
 
-        bs = f_spe.size(0)
+        bs = f_share.size(0)
         # using idx aug in the training mode
         aug_idx = random.random()
         if aug_idx < 0.7:

--- a/training/detectors/ucf_detector.py
+++ b/training/detectors/ucf_detector.py
@@ -281,7 +281,7 @@ class UCFDetector(AbstractDetector):
             pred_dict = {'cls': out_sha, 'feat': sha_feat}
             return  pred_dict
 
-        bs = self.config['train_batchSize']
+        bs = f_spe.size(0)
         # using idx aug in the training mode
         aug_idx = random.random()
         if aug_idx < 0.7:


### PR DESCRIPTION
The current implementation of the UCF detector loads the batch size in the forward pass from the config file. This is faulty for two reasons:

- The last batch can have a different size from the one specified in the config file (in case train_sample is not divisible by train_batchSize).
- The actual batch size loaded by the dataloader is twice the size of the batch size specified in the config file. This is because the UCF model requires each batch to have as many real samples as fake ones. So for example if one selects a batch size of 28 in the config file the actual batch size loaded by the dataloader will be 56. 

Anyway, it is best practice to get the batch size by using the shape/ size of the batch you are currently processing dynamically rather than loading a predefined value. 