### PR TITLE
bug fix ZeroDivisionError: float division by zero

### DIFF
--- a/training/dataset/albu.py
+++ b/training/dataset/albu.py
@@ -26,7 +26,7 @@ def isotropically_resize_image(img, size, interpolation_down=cv2.INTER_AREA, int
 class IsotropicResize(DualTransform):
     def __init__(self, max_side, interpolation_down=cv2.INTER_AREA, interpolation_up=cv2.INTER_CUBIC,
                  always_apply=False, p=1):
-        super(IsotropicResize, self).__init__(always_apply, p)
+        super(IsotropicResize, self).__init__(p)
         self.max_side = max_side
         self.interpolation_down = interpolation_down
         self.interpolation_up = interpolation_up


### PR DESCRIPTION
自定义实现的IsotropicResize 位置参数未正确传递概率 p，导致默认初始化概率为 0，在使用 A.Oneof 时报除零错误